### PR TITLE
Debugged token refresh for Google users

### DIFF
--- a/backend/api/server.js
+++ b/backend/api/server.js
@@ -183,18 +183,6 @@ server.post("/auth/google", async (req, res) => {
   }
 });
 
-// refresh access token for user, set new token based on given google_id
-server.post("/auth/google/refresh-token", async (req, res) => {
-  const user = await prisma.user.findUnique({
-    where: { id: req.session.userId },
-  });
-  oAuth2Client.setCredentials({
-    refresh_token: user.refresh_token,
-  });
-  // TODO: prisma update with new access token and expiry date
-  res.json(credentials);
-});
-
 // checks if google account already has profile (login), otherwise registers
 server.post("/auth/google/login", async (req, res) => {
   const {
@@ -222,7 +210,6 @@ server.post("/auth/google/login", async (req, res) => {
 
   if (existingUser) {
     // accounts exists, set logged in user
-    // TODO: check if access expires soon, if so refresh
     req.session.userId = existingUser.id;
 
     const updated = await prisma.user.update({

--- a/backend/middleware/middleware.js
+++ b/backend/middleware/middleware.js
@@ -8,24 +8,22 @@ const PROD = process.env.PROD;
 
 const getNewAccessToken = async (user) => {
   // get new access token using refresh token
-  let payload = {
+  const params = new URLSearchParams({
     grant_type: "refresh_token",
     refresh_token: user.refresh_token,
     client_id: process.env.CLIENT_ID,
     client_secret: process.env.CLIENT_SECRET,
-  };
+  }).toString();
 
+  // google requires the information to be URL
   try {
-    const response = await fetch(
-      `https://oauth2.googleapis.com/token`,
-      payload,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json;",
-        },
-      }
-    );
+    const response = await fetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: params,
+    });
 
     if (!response.ok) {
       throw new Error("Token refresh failed.");
@@ -40,6 +38,7 @@ const getNewAccessToken = async (user) => {
 router.use(async (req, res, next) => {
   res.setHeader("Access-Control-Allow-Origin", PROD || DEV);
 
+  // get user information to check access
   if (req.session.userId) {
     const user = await prisma.user.findUnique({
       where: { id: req.session.userId },
@@ -50,23 +49,29 @@ router.use(async (req, res, next) => {
       },
     });
 
-    // TODO: get token refresh completed
+    // if google user and access is expired, get new token
     if (user.auth_provider === "google") {
       const expiration = new Date(user.token_expiry);
       const deadline = new Date();
+
       if (expiration <= deadline) {
         // refresh token
         try {
           const credentials = await getNewAccessToken(user);
+          // find new expiration date
+          const now = new Date();
+          const token_expiry = new Date(
+            now.getTime() + credentials.expires_in * 1000
+          );
           const updated = await prisma.user.update({
-            data: { access_token: credentials },
+            data: { access_token: credentials.access_token },
             where: { id: req.session.userId },
           });
         } catch (error) {
           req.session.destroy(() => {
             res.clearCookie("connect.sid");
             res.status(401).json({
-              error: "Failed to update access token. Please log in again.",
+              error: "Failed to update Google login. Please log in again.",
             });
           });
           return;


### PR DESCRIPTION
**Description**
- Updated middleware to refresh token for google-auth users if the access token is expired
- Debugged by using URL encoded body instead of JSON

**Resources**
- [Google Documentation](https://developers.google.com/identity/protocols/oauth2/web-server#node.js_9) includes example for revoking access token, which uses 'application/x-www-form-urlencoded'

**Testing**
- Ran token refresh on login (temporarily removed the expiration date check) and was able to updated the access and expiration date